### PR TITLE
Update to lexical v7.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ smallnumberbuf = [ "smallvec" ]
 canonical = [ "ryu-js" ]
 
 [dependencies]
-lexical = { version = "6.1.1", features = [ "format" ] }
+lexical = { version = "7.0.1", features = [ "format" ] }
 smallvec = { version = "1.8.1", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,11 +425,11 @@ impl Number {
 	}
 }
 
-const LOSSY_PARSE_FLOAT: lexical::ParseFloatOptions = unsafe {
+const LOSSY_PARSE_FLOAT: lexical::ParseFloatOptions =
 	lexical::ParseFloatOptions::builder()
 		.lossy(true)
 		.build_unchecked()
-};
+;
 
 impl Deref for Number {
 	type Target = str;
@@ -686,12 +686,12 @@ pub enum TryFromFloatError {
 	Infinite,
 }
 
-const WRITE_FLOAT: lexical::WriteFloatOptions = unsafe {
+const WRITE_FLOAT: lexical::WriteFloatOptions =
 	lexical::WriteFloatOptions::builder()
 		.trim_floats(true)
 		.exponent(b'e')
 		.build_unchecked()
-};
+;
 
 macro_rules! impl_try_from_float {
 	($($ty:ty),*) => {


### PR DESCRIPTION
report from cargo deny

```
error[unsound]: Multiple soundness issues
    ┌─ (... anonymized ...)
    │
235 │ lexical-core 0.8.5 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
    │
    ├ ID: RUSTSEC-2023-0086
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0086
    ├ `RUSTSEC-2024-0377` contains multiple soundness issues:
      
       1. [Bytes::read() allows creating instances of types with invalid bit patterns](https://github.com/Alexhuszagh/rust-lexical/issues/102)
       1. [BytesIter::read() advances iterators out of bounds](https://github.com/Alexhuszagh/rust-lexical/issues/101)
       1. [The `BytesIter` trait has safety invariants but is public and not marked `unsafe`](https://github.com/Alexhuszagh/rust-lexical/issues/104)
       1. [`write_float()` calls `MaybeUninit::assume_init()` on uninitialized data, which is is not allowed by the Rust abstract machine](https://github.com/Alexhuszagh/rust-lexical/issues/95)
       1. [`radix()` calls `MaybeUninit::assume_init()` on uninitialized data, which is is not allowed by the Rust abstract machine](https://github.com/Alexhuszagh/rust-lexical/issues/126)
      
      Version 1.0 fixes these issues, removes the vast majority of `unsafe` code, and also fixes some correctness issues.
    ├ Solution: Upgrade to >=1.0.0 (try `cargo update -p lexical-core`)
    ├ lexical-core v0.8.5
      └── lexical v6.1.1
          └── json-number v0.4.8
```