### PR TITLE
chore(deps): update lexical dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ readme = "README.md"
 
 [features]
 default = []
-smallnumberbuf = [ "smallvec" ]
-canonical = [ "ryu-js" ]
+smallnumberbuf = ["smallvec"]
+canonical = ["ryu-js"]
 
 [dependencies]
-lexical = { version = "6.1.1", features = [ "format" ] }
+lexical = { version = "7.0", features = ["format"] }
 smallvec = { version = "1.8.1", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }


### PR DESCRIPTION
Update to latest version of lexical crate, this is required to address the following security advisories:

- lexical: RUSTSEC-2023-0055
- lexical-core (a transitive dependency of lexical): RUSTSEC-2023-0086

This fixes https://github.com/timothee-haudebourg/json-number/issues/4
