### PR TITLE
chore(deps): relax dependencies and update them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ smallnumberbuf = [ "smallvec" ]
 canonical = [ "ryu-js" ]
 
 [dependencies]
-lexical = { version = "7.0.1", features = [ "format" ] }
-smallvec = { version = "1.8.1", optional = true }
+lexical = { version = "7.0", features = [ "format" ] }
+smallvec = { version = "1.13", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-ryu-js = { version = "0.2.2", optional = true }
+ryu-js = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1", features = ["arbitrary_precision"] }


### PR DESCRIPTION
Do not require patch level releases for dependencies. Also, update some outdated dependencies.
